### PR TITLE
Cargo.toml: mark project as MIT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "glade-bindgen"
 version = "1.0.0"
 authors = ["djdisodo <djdisodo@gmail.com>"]
-license-file = "LICENSE.md"
+license = "MIT"
 description = "library to generate gtk glade bind"
 repository = "https://github.com/djdisodo/glade-bindgen"
 readme = "README.md"


### PR DESCRIPTION
The crates.io website has trouble finding out the license of the project, because the LICENSE.md file contains your name inside of it and thus is non-usual.

![Screenshot of the crates.io website displaying "License: non-standard"](https://user-images.githubusercontent.com/989521/124514283-f81b1480-dddc-11eb-9ebf-be84d27da616.png)

By directly specifying that the project is under the MIT license in the Cargo.toml file, we can help crates.io display the proper license on the crate's page.