### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,12 +97,12 @@ pub fn generate_bind<T: AsRef<Path>>(name: Ident, file: File, file_include_dir: 
 			Ok(XmlEvent::StartElement { name, attributes, .. }) => {
 				if &name.local_name == "object" {
 					let id = attributes.iter().find(| attr | attr.name.local_name == "id");
-					if id.is_some() {
+					if let Some(id) = id {
 						let class = attributes.iter().find(| attr | attr.name.local_name == "class");
-						if class.is_some() {
-							let class = class.unwrap().value.to_owned();
+						if let Some(class) = class {
+							let class = class.value.to_owned();
 							let class_ident = format_ident!("{}", class.replace("Gtk", ""));
-							let id = id.unwrap().value.to_owned();
+							let id = id.value.to_owned();
 							let id_ident = format_ident!("{}", &id);
 							objects.extend::<TokenStream2>(quote!{
 								pub #id_ident: gtk::#class_ident,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub fn generate_bind_recursive<T: AsRef<Path>>(directory_path: T, build_script: 
 		});
 	}
 	for x in generated_token_streams {
-		token_stream.extend::<TokenStream2>(x.into());
+		token_stream.extend::<TokenStream2>(x);
 	}
 
 	let mut mod_path = PathBuf::from(directory_path.as_ref());
@@ -106,7 +106,7 @@ pub fn generate_bind<T: AsRef<Path>>(name: Ident, file: File, file_include_dir: 
 							let id_ident = format_ident!("{}", &id);
 							objects.extend::<TokenStream2>(quote!{
 								pub #id_ident: gtk::#class_ident,
-							}.into());
+							});
 							objects_new.extend::<TokenStream2>(quote! {
 								#id_ident: gtk::prelude::BuilderExtManual::object(&builder, #id).unwrap(),
 							})
@@ -164,7 +164,7 @@ pub fn generate_bind<T: AsRef<Path>>(name: Ident, file: File, file_include_dir: 
 			}
 		}
 	};
-	token_stream.into()
+	token_stream
 }
 /*
 struct Args(Ident, LitStr);


### PR DESCRIPTION
Fix warnings found using clippy:

```
$ cargo clippy --all-targets               
    Checking glade-bindgen v1.1.0 (/home/microjoe/dev/glade-bindgen)
warning: useless conversion to the same type: `proc_macro2::TokenStream`
  --> src/lib.rs:66:39
   |
66 |         token_stream.extend::<TokenStream2>(x.into());
   |                                             ^^^^^^^^ help: consider removing `.into()`: `x`
   |
   = note: `#[warn(clippy::useless_conversion)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: you checked before that `unwrap()` cannot fail, instead of checking and unwrapping, it's better to use `if let` or `match`
   --> src/lib.rs:103:20
    |
102 |                         if class.is_some() {
    |                            --------------- the check is happening here
103 |                             let class = class.unwrap().value.to_owned();
    |                                         ^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::unnecessary_unwrap)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap

warning: you checked before that `unwrap()` cannot fail, instead of checking and unwrapping, it's better to use `if let` or `match`
   --> src/lib.rs:105:17
    |
100 |                     if id.is_some() {
    |                        ------------ the check is happening here
...
105 |                             let id = id.unwrap().value.to_owned();
    |                                      ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap

warning: useless conversion to the same type: `proc_macro2::TokenStream`
   --> src/lib.rs:107:39
    |
107 |   ...                   objects.extend::<TokenStream2>(quote!{
    |  ______________________________________________________^
108 | | ...                       pub #id_ident: gtk::#class_ident,
109 | | ...                   }.into());
    | |______________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into()`
    |
107 |                             objects.extend::<TokenStream2>(quote!{
108 |                                 pub #id_ident: gtk::#class_ident,
109 |                             });
    |

warning: useless conversion to the same type: `proc_macro2::TokenStream`
   --> src/lib.rs:167:2
    |
167 |     token_stream.into()
    |     ^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `token_stream`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: useless conversion to the same type: `proc_macro2::TokenStream`
  --> src/lib.rs:66:39
   |
66 |         token_stream.extend::<TokenStream2>(x.into());
   |                                             ^^^^^^^^ help: consider removing `.into()`: `x`
   |
   = note: `#[warn(clippy::useless_conversion)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: you checked before that `unwrap()` cannot fail, instead of checking and unwrapping, it's better to use `if let` or `match`
   --> src/lib.rs:103:20
    |
102 |                         if class.is_some() {
    |                            --------------- the check is happening here
103 |                             let class = class.unwrap().value.to_owned();
    |                                         ^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::unnecessary_unwrap)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap

warning: you checked before that `unwrap()` cannot fail, instead of checking and unwrapping, it's better to use `if let` or `match`
   --> src/lib.rs:105:17
    |
100 |                     if id.is_some() {
    |                        ------------ the check is happening here
...
105 |                             let id = id.unwrap().value.to_owned();
    |                                      ^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap

warning: 5 warnings emitted

warning: useless conversion to the same type: `proc_macro2::TokenStream`
   --> src/lib.rs:107:39
    |
107 |   ...                   objects.extend::<TokenStream2>(quote!{
    |  ______________________________________________________^
108 | | ...                       pub #id_ident: gtk::#class_ident,
109 | | ...                   }.into());
    | |______________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into()`
    |
107 |                             objects.extend::<TokenStream2>(quote!{
108 |                                 pub #id_ident: gtk::#class_ident,
109 |                             });
    |

warning: useless conversion to the same type: `proc_macro2::TokenStream`
   --> src/lib.rs:167:2
    |
167 |     token_stream.into()
    |     ^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `token_stream`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: 5 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
```