### PR TITLE
Introduce GitHub actions CI for crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gtk-rs/gtk3-rs/gtk3:latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+          - "1.51.0"
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        override: true
+    - name: Build
+      run: cargo build --verbose
+    # clippy
+    - run: rustup component add clippy
+      if: matrix.rust == 'beta' || matrix.rust == 'stable'
+    - working-directory: ${{ matrix.conf.name }}
+      name: clippy ${{ matrix.conf.name }}
+      run: cargo clippy --all-targets -- -D warnings
+      if: matrix.rust == 'beta' || matrix.rust == 'stable'
+    # tests
+    - name: Run tests
+      run: xvfb-run --auto-servernum cargo test --verbose
+    - uses: bcomnes/cleanup-xvfb@v1


### PR DESCRIPTION
[GitHub actions](https://docs.github.com/en/actions) can be used to automatically build the crate and run various tests. You can see it in action in the [gladis](https://github.com/MicroJoe/gladis/actions) crate for example.

This should be merged after #5 in order to have a successful build, as it will run `clippy` automatically.