### PR TITLE
add support for "*.ui" files, use regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ categories = ["development-tools::build-utils", "gui"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+regex = "1.5"
+lazy_static = "1.4"
 quote = "1.0"
 xml-rs = "0.8"
 convert_case = "0.4"


### PR DESCRIPTION
In the official GTK documentation, the .ui file extension is used to
contain the XML payload describing the user interface. Meanwhile, glade
is saving its files using the .glade file extension.

Both extensions should be supported.

A new dependency to the `regex` crate was introduced, as it was
suggested by a comment in the code. This allows to match and replace
both file extensions.

A dependency to the `lazy_static` crate has been introduced as well, in
order to compile the regex only once during startup, and not every time
the generate_bind_recursive() function is called.

A separate function has been created in order to be able to write some
unit tests to verify its behavior. It should be inlined by the compiler,
leading to zero additional cost.